### PR TITLE
Installing Ruby, Python, PHP, Nodejs via deb packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN circleci-install docker_compose
 
 # When running in unprivileged containers, need to use CircleCI Docker fork
 ARG TARGET_UNPRIVILEGED_LXC
-RUN if [ "n$TARGET_UNPRIVILEGED_LXC" = "ntrue" ]; then circleci-install circleci_docker; fi
+RUN if [ "$TARGET_UNPRIVILEGED_LXC" = "true" ]; then circleci-install circleci_docker; fi
 
 # Undivert upstart
 RUN rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM circleci/ubuntu-server:trusty-latest
 
 # Avoid any installation scripts interact with upstart
 # So divert now, but undivert at the end
+# You shouldn't change the line unless you understad the consequence
 RUN echo 'exit 101' > /usr/sbin/policy-rc.d \
 	&& chmod +x /usr/sbin/policy-rc.d \
         && dpkg-divert --local --rename --add /sbin/initctl \
@@ -89,6 +90,7 @@ ARG TARGET_UNPRIVILEGED_LXC
 RUN if [ "$TARGET_UNPRIVILEGED_LXC" = "true" ]; then circleci-install circleci_docker; fi
 
 # Undivert upstart
+# You shouldn't change the line unless you understad the consequence
 RUN rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl
 
 LABEL circleci.user="ubuntu"

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,41 @@ RUN circleci-install android_sdk platform-tools
 RUN circleci-install android_sdk android-22
 RUN circleci-install android_sdk android-23
 
+# Qt
+ADD circleci-provision-scripts/qt.sh /opt/circleci-provision-scripts/qt.sh
+RUN circleci-install qt
+
+# awscli
+ADD circleci-provision-scripts/awscli.sh /opt/circleci-provision-scripts/awscli.sh
+RUN circleci-install awscli
+
 # Languages
+ARG use_precompile
+ENV USE_PRECOMPILE $use_precompile
+RUN curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | sudo bash
+
 ADD circleci-provision-scripts/python.sh /opt/circleci-provision-scripts/python.sh
+RUN circleci-install python 2.7.11
+RUN circleci-install python 3.1.5
+RUN circleci-install python 3.3.6
 RUN circleci-install python 3.5.1
+RUN circleci-install python pypy-1.9
+RUN circleci-install python pypy-2.6.1
+RUN circleci-install python pypy-4.0.1
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; pyenv global 2.7.11"
 
 ADD circleci-provision-scripts/nodejs.sh /opt/circleci-provision-scripts/nodejs.sh
-RUN circleci-install nodejs v5.1.1
+RUN circleci-install nodejs 0.12.9
+RUN circleci-install nodejs 4.0.0
+RUN circleci-install nodejs 4.1.2
+RUN circleci-install nodejs 4.2.6
+RUN circleci-install nodejs 5.0.0
+RUN circleci-install nodejs 5.1.1
+RUN circleci-install nodejs 5.2.0
+RUN circleci-install nodejs 5.4.1
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; nvm alias default 4.2.6"
 
 ADD circleci-provision-scripts/java.sh /opt/circleci-provision-scripts/java.sh
 RUN circleci-install java
@@ -60,25 +89,25 @@ ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
 RUN circleci-install golang 1.5.2
 
 ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
-RUN circleci-install ruby 2.2.2
+RUN circleci-install ruby 2.0.0-p647
+RUN circleci-install ruby 2.1.8
+RUN circleci-install ruby 2.2.4
+RUN circleci-install ruby 2.3.0
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; rvm use 2.2.4 --default"
 
 ADD circleci-provision-scripts/php.sh /opt/circleci-provision-scripts/php.sh
-RUN circleci-install php 5.6.16
-RUN circleci-install php 7.0.0
+RUN circleci-install php 5.5.31
+RUN circleci-install php 5.6.17
+RUN circleci-install php 7.0.2
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; phpenv global 5.6.17"
 
 ADD circleci-provision-scripts/clojure.sh /opt/circleci-provision-scripts/clojure.sh
 RUN circleci-install clojure
 
 ADD circleci-provision-scripts/scala.sh /opt/circleci-provision-scripts/scala.sh
 RUN circleci-install scala
-
-# Qt
-ADD circleci-provision-scripts/qt.sh /opt/circleci-provision-scripts/qt.sh
-RUN circleci-install qt
-
-# awscli
-ADD circleci-provision-scripts/awscli.sh /opt/circleci-provision-scripts/awscli.sh
-RUN circleci-install awscli
 
 # Docker have be last - to utilize cache better
 ADD circleci-provision-scripts/docker.sh /opt/circleci-provision-scripts/docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ ADD circleci-provision-scripts/postgres.sh /opt/circleci-provision-scripts/postg
 RUN circleci-install postgres
 
 ADD circleci-provision-scripts/misc.sh /opt/circleci-provision-scripts/misc.sh
+RUN circleci-install sysadmin
+RUN circleci-install devtools
 RUN circleci-install redis
 RUN circleci-install memcached
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Basic CircleCI Image Builder
+# CircleCI Image Builder
 
 This demos a process to build CircleCI compatible containers for use in CircleCI Enterprise.
 We love feedback - please reach out!
@@ -32,11 +32,13 @@ RUN update-ca-certificates
 
 And then you can build it as you would typically do (i.e. `docker build -t my-container:0.3 .`).
 
+Another common tweak is removing packages/tools that you don't use. For example, if you don't have
+Android projects, you should remove the lines that install Android SDKs from the Dockerfile.
+We encourage you to install only what you need because having a smaller container image will give you many benefits such as faster container start up time.
+
 With this workflow, you will be basing your container on CircleCI published container image,
 speeding up creation process.  When CircleCI publishes new container image, you can rebuild
 your image and Docker will pick up the latest published version.
-
-**TODO**: Document available base image and document them
 
 ## Building a container with substantial changes
 
@@ -107,8 +109,6 @@ ubuntu=# ;; psql is running
 ubuntu=# ;; psql is running
 ubuntu-# \quit
 ```
-
-**TODO**: Offer automated testing, in a similar style to [Docker official image testing](https://github.com/docker-library/official-images/tree/master/test).
 
 # 3. Hooking up CircleCI to use the container
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ we suggest exporting the container and uploading it to S3.
 
 Assuming you have the official aws-cli client, you can export the container and
 upload it to a bucket of your choice.  Ideally, it's located in the same region
-as the builders, and you can reuse the bucket that got created for the CCIE installation:
+as the builders, and you can reuse the bucket that got created for the CCIE installation
+':
 
+(_note: this uses the included `docker-export`, which is different than `docker export`_)
 ```bash
 $ ./docker-export example-image > example-image_0.0.1.tar.gz
 $ aws s3 cp ./example-image_0.0.1.tar.gz s3://circleci-enterprise-bucket/containers/example-image_0.0.1.tar.gz

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
     - docker push circleci/build-image:trusty-${IMAGE_TAG}
 
     # Build a slightly modified image for unprivileged lxc
-    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=yes -t circleci/build-image:scratch-unprivileged .:
+    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true -t circleci/build-image:scratch-unprivileged .:
         timeout: 3600
 
     - docker tag circleci/build-image:scratch circleci/build-image:trusty-${IMAGE_TAG}-unprivileged

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ test:
     - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true -t circleci/build-image:scratch-unprivileged .:
         timeout: 3600
 
-    - docker tag circleci/build-image:scratch circleci/build-image:trusty-${IMAGE_TAG}-unprivileged
+    - docker tag circleci/build-image:scratch-unprivileged circleci/build-image:trusty-${IMAGE_TAG}-unprivileged
     - docker push circleci/build-image:scratch:
         timeout: 3600
     - docker push circleci/build-image:trusty-${IMAGE_TAG}-unprivileged

--- a/circle.yml
+++ b/circle.yml
@@ -20,23 +20,30 @@ test:
         timeout: 3600
 
     - docker tag circleci/build-image:scratch circleci/build-image:trusty-${IMAGE_TAG}
+
     - docker push circleci/build-image:scratch:
         timeout: 3600
+
     - docker push circleci/build-image:trusty-${IMAGE_TAG}
 
     # Build a slightly modified image for unprivileged lxc
-    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true -t circleci/build-image:scratch-unprivileged .:
+    - docker pull circleci/build-image:scratch-unprivileged || true:
+        timeout: 3600
+
+    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true --build-arg use_precompile=true -t circleci/build-image:scratch-unprivileged .:
         timeout: 3600
 
     - docker tag circleci/build-image:scratch-unprivileged circleci/build-image:trusty-${IMAGE_TAG}-unprivileged
-    - docker push circleci/build-image:scratch:
+
+    - docker push circleci/build-image:scratch-unprivileged:
         timeout: 3600
-    - docker push circleci/build-image:trusty-${IMAGE_TAG}-unprivileged
+
+    - docker push circleci/build-image:trusty-${IMAGE_TAG}-unprivileged:
+        timeout: 3600
 
 deployment:
   release:
     tag: /v.*/
     commands:
-      - ./docker-export circleci/build-image:scratch-unprivileged > trusty-beta-${CIRCLE_TAG}.tar.gz:
+      - ./docker-export circleci/build-image:scratch-unprivileged | aws s3 cp - s3://circle-downloads/trusty-beta-${CIRCLE_TAG}.tar.gz --acl public-read:
           timeout: 3600
-      - aws s3 cp trusty-beta-${CIRCLE_TAG}.tar.gz s3://circle-downloads/ --acl public-read

--- a/circleci-install
+++ b/circleci-install
@@ -2,6 +2,13 @@
 
 [ -n "$CIRCLECI_USER" ] || export CIRCLECI_USER=ubuntu
 export CIRCLECI_HOME=/home/${CIRCLECI_USER}
+export CIRCLECI_PKG_DIR=/opt/circleci
+
+if ! [ -d $CIRCLECI_PKG_DIR ]; then
+    mkdir -p $CIRCLECI_PKG_DIR
+fi
+
+chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR
 
 function as_user() {
     sudo -H -u ${CIRCLECI_USER} $@

--- a/circleci-provision-scripts/base.sh
+++ b/circleci-provision-scripts/base.sh
@@ -47,10 +47,31 @@ EOF
     apt-get update -y
 
     # Install base packages
-    apt-get install \
-        build-essential cmake git-core mercurial zip gdb \
-        htop emacs vim nano lsof vnc4server tmux lzop \
-        build-essential htop emacs vim nano lsof tmux zip vnc4server \
-        curl unzip git-core ack-grep software-properties-common build-essential \
-        parallel libav-tools make autoconf liblapack-dev gfortran
+    cat << EOS | xargs apt-get install
+ack-grep
+autoconf
+bsdtar
+build-essential
+cmake
+curl
+emacs
+gdb
+gfortran
+git-core
+htop
+libav-tools
+liblapack-dev
+lsof
+lzop
+make
+mercurial
+nano
+parallel
+software-properties-common
+tmux
+unzip
+vim
+vnc4server
+zip
+EOS
 }

--- a/circleci-provision-scripts/base.sh
+++ b/circleci-provision-scripts/base.sh
@@ -48,30 +48,21 @@ EOF
 
     # Install base packages
     cat << EOS | xargs apt-get install
-ack-grep
 autoconf
 bsdtar
 build-essential
 cmake
 curl
-emacs
-gdb
 gfortran
 git-core
-htop
 libav-tools
 liblapack-dev
-lsof
 lzop
 make
 mercurial
-nano
 parallel
 software-properties-common
-tmux
 unzip
-vim
-vnc4server
 zip
 EOS
 }

--- a/circleci-provision-scripts/circleci-specific.sh
+++ b/circleci-provision-scripts/circleci-specific.sh
@@ -8,6 +8,9 @@ function install_circleci_specific() {
     echo 'source ~/.bashrc &>/dev/null' >> ${CIRCLECI_HOME}/.bash_profile
     echo 'source ~/.circlerc &>/dev/null' > ${CIRCLECI_HOME}/.bashrc
 
+    chown $CIRCLECI_USER:$CIRCLECI_USER ${CIRCLECI_HOME}/.bash_profile
+    chown $CIRCLECI_USER:$CIRCLECI_USER ${CIRCLECI_HOME}/.bashrc
+
     (cat <<'EOF'
 export GIT_ASKPASS=echo
 export SSH_ASKPASS=false

--- a/circleci-provision-scripts/misc.sh
+++ b/circleci-provision-scripts/misc.sh
@@ -7,3 +7,22 @@ function install_redis() {
 function install_memcached() {
     apt-get install memcached libmemcache-dev
 }
+
+function install_sysadmin() {
+    cat << EOS | xargs apt-get install
+htop
+EOS
+}
+
+function install_devtools() {
+    cat << EOS | xargs apt-get install
+ack-grep
+emacs
+gdb
+lsof
+nano
+tmux
+vim
+vnc4server
+EOS
+}

--- a/circleci-provision-scripts/nodejs.sh
+++ b/circleci-provision-scripts/nodejs.sh
@@ -5,18 +5,39 @@ function install_nvm() {
 
     apt-get install build-essential libssl-dev make python g++ curl libssl-dev
 
-    echo 'Install VNM'
+    echo 'Install NVM'
     (cat <<'EOF'
 set -ex
-cd ~
-[[ -e nvm ]] || git clone https://github.com/creationix/nvm.git nvm
-mkdir -p nvm/log
-echo 'source ~/nvm/nvm.sh' >> ~/.circlerc
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | NVM_DIR=$CIRCLECI_PKG_DIR/.nvm bash
+echo "export NVM_DIR=$CIRCLECI_PKG_DIR/.nvm" >> ~/.circlerc
+echo 'source $NVM_DIR/nvm.sh' >> ~/.circlerc
 EOF
-    ) | as_user bash
+    ) | as_user CIRCLECI_PKG_DIR=$CIRCLECI_PKG_DIR bash
+
+
+    if [ -n "$USE_PRECOMPILE" ]; then
+        patch_nvm_always_delete_npm_prefix
+
+        # Preparing for hooking up packaged NodeJS into nvm directories
+        (cat <<'EOF'
+set -ex
+mkdir $CIRCLECI_PKG_DIR/nodejs
+mkdir $CIRCLECI_PKG_DIR/.nvm/versions
+ln -s $CIRCLECI_PKG_DIR/nodejs $CIRCLECI_PKG_DIR/.nvm/versions/node
+
+EOF
+        ) | as_user CIRCLECI_PKG_DIR=$CIRCLECI_PKG_DIR bash
+    fi
 }
 
-function install_nodejs_version() {
+# This is a kind of hack to prevent 'nvm is not compatible with the npm config "prefix" option' error
+# when you run `nvm use vX.Y.Z`. We get this error because nvm expects nodejs to be installed under $NVM_DIR
+# but we actually install under /opt/circleci/nodejs.
+function patch_nvm_always_delete_npm_prefix() {
+     sed -i 's/NVM_DELETE_PREFIX=0/NVM_DELETE_PREFIX=1/' $CIRCLECI_PKG_DIR/.nvm/nvm.sh
+}
+
+function install_nodejs_version_nvm() {
     NODEJS_VERSION=$1
     (cat <<'EOF'
 set -ex
@@ -24,13 +45,10 @@ source ~/.circlerc
 nvm install $NODEJS_VERSION
 rm -rf ~/nvm/src
 hash -r
-
 nvm use $NODEJS_VERSION
-
 # tell npm to use known registrars for CA certs -
 # http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
 npm config set ca "" --global
-
 # Install some common libraries
 npm install -g npm
 npm install -g coffee-script
@@ -40,15 +58,33 @@ npm install -g grunt-cli
 npm install -g nodeunit
 npm install -g mocha
 hash -r
-
 EOF
     ) | as_user NODEJS_VERSION=$NODEJS_VERSION bash
 
     set_nodejs_default $NODEJS_VERSION
 }
 
+function install_nodejs_version_precompile() {
+    local NODEJS_VERSION=$1
+
+    apt-get install circleci-nodejs-$NODEJS_VERSION
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/nodejs
+    set_nodejs_default $NODEJS_VERSION
+}
+
+function install_nodejs_version() {
+    local VERSION=$1
+
+    if [ -n "$USE_PRECOMPILE" ]; then
+        install_nodejs_version_precompile $VERSION
+    else
+        install_nodejs_version_nvm $VERSION
+    fi
+}
+
 function set_nodejs_default() {
-    NODEJS_VERSION=$1
+    local NODEJS_VERSION=$1
+
     (cat <<'EOF'
 set -ex
 source ~/.circlerc
@@ -58,7 +94,8 @@ EOF
 }
 
 function install_nodejs() {
-    VERSION=$1
-    [[ -e $CIRCLECI_HOME/nvm ]] || install_nvm
-    install_nodejs_version $1
+    local NODEJS_VERSION=$1
+
+    [[ -e $CIRCLECI_PKG_DIR/.nvm ]] || install_nvm
+    install_nodejs_version $NODEJS_VERSION
 }

--- a/circleci-provision-scripts/ruby.sh
+++ b/circleci-provision-scripts/ruby.sh
@@ -4,11 +4,9 @@ function install_rvm() {
     echo '>>> Installing RVM and Ruby'
 
     as_user gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-    curl -sSL https://get.rvm.io | as_user bash -s stable --ruby
+    curl -sSL https://get.rvm.io | as_user bash -s -- --path $CIRCLECI_PKG_DIR/.rvm
 
-    ln -sf ${CIRCLECI_HOME}/.rvm /usr/local/rvm
-
-    echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm" # Load RVM function' | as_user tee -a ${CIRCLECI_HOME}/.circlerc
+    echo "[[ -s '$CIRCLECI_PKG_DIR/.rvm/scripts/rvm' ]] && . $CIRCLECI_PKG_DIR/.rvm/scripts/rvm # Load RVM function" | as_user tee -a ${CIRCLECI_HOME}/.circlerc
 
     # Setting up user rmvrc
 
@@ -35,35 +33,58 @@ source ~/.circlerc
 rvm rvmrc warning ignore allGemfiles
 EOF
     ) | as_user bash
+
+    if [ -n "$USE_PRECOMPILE" ]; then
+    # Preparing for hooking up packaged Ruby into rvm directories
+
+    (cat <<'EOF'
+set -ex
+mkdir $CIRCLECI_PKG_DIR/ruby
+rm -r $CIRCLECI_PKG_DIR/.rvm/rubies
+ln -s $CIRCLECI_PKG_DIR/ruby $CIRCLECI_PKG_DIR/.rvm/rubies
+EOF
+    ) | as_user CIRCLECI_PKG_DIR=$CIRCLECI_PKG_DIR bash
+    fi
 }
 
-
-function install_ruby_version() {
+function install_ruby_version_rvm() {
     INSTALL_RUBY_VERSION=$1
     RUBYGEMS_MAJOR_RUBY_VERSION=${2:-2}
     (cat <<'EOF'
-
 set -ex
-
 echo Installing Ruby version: $INSTALL_RUBY_VERSION
-
 source ~/.circlerc
-
 rvm use $INSTALL_RUBY_VERSION
-
 # TODO: Avoid this for jruby
 rvm rubygems latest-${RUBYGEMS_MAJOR_RUBY_VERSION}
 rvm @global do gem install bundler -v 1.9.5
-
 # For projects without gemfiles
 rvm @global do gem install rspec
-
 EOF
     ) | as_user INSTALL_RUBY_VERSION=$INSTALL_RUBY_VERSION RUBYGEMS_MAJOR_RUBY_VERSION=$RUBYGEMS_MAJOR_RUBY_VERSION bash
 }
 
+function install_ruby_version_precompile() {
+    local INSTALL_RUBY_VERSION=$1
+    echo ">>> Installing Ruby $INSTALL_RUBY_VERSION"
+
+    apt-get install circleci-ruby-$INSTALL_RUBY_VERSION
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/ruby/
+}
+
+function install_ruby_version() {
+    local VERSION=$1
+
+    if [ -n "$USE_PRECOMPILE" ]; then
+        install_ruby_version_precompile $VERSION
+    else
+        install_ruby_version_rvm $VERSION
+    fi
+}
+
 function install_ruby() {
-    VERSION=$1
-    [[ -e $CIRCLECI_HOME/.rvm ]] || install_rvm
-    install_ruby_version $1
+    local VERSION=$1
+
+    [[ -e $CIRCLECI_PKG_DIR/.rvm ]] || install_rvm
+    install_ruby_version $VERSION
 }


### PR DESCRIPTION
Installing Ruby, Python, PHP, Nodejs from pre-compiled package: https://packagecloud.io/circleci/trusty

Everything will be installed under `/opt/circleci` and *vm and *env will refer the installed packages with symbolic link.

We also install more versions for each language in this change. We will install all major and minor version of the latest patch release.