### PR TITLE
Splitting Dockerfile for enterprise and dotcom

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,52 @@
+FROM circleci/ubuntu-server:trusty-latest
+
+# Avoid any installation scripts interact with upstart
+# So divert now, but undivert at the end
+# You shouldn't change the line unless you understad the consequence
+RUN echo 'exit 101' > /usr/sbin/policy-rc.d \
+	&& chmod +x /usr/sbin/policy-rc.d \
+        && dpkg-divert --local --rename --add /sbin/initctl \
+        && ln -s /bin/true /sbin/initctl
+
+ADD circleci-install /usr/local/bin/circleci-install
+
+ADD circleci-provision-scripts/base.sh /opt/circleci-provision-scripts/base.sh
+ADD circleci-provision-scripts/circleci-specific.sh /opt/circleci-provision-scripts/circleci-specific.sh
+RUN circleci-install base_requirements  && circleci-install circleci_specific
+
+# Databases
+ADD circleci-provision-scripts/mysql.sh /opt/circleci-provision-scripts/mysql.sh
+RUN circleci-install mysql_56
+
+ADD circleci-provision-scripts/mongo.sh /opt/circleci-provision-scripts/mongo.sh
+RUN circleci-install mongo
+
+ADD circleci-provision-scripts/postgres.sh /opt/circleci-provision-scripts/postgres.sh
+RUN circleci-install postgres
+
+ADD circleci-provision-scripts/misc.sh /opt/circleci-provision-scripts/misc.sh
+RUN circleci-install sysadmin
+RUN circleci-install devtools
+RUN circleci-install redis
+RUN circleci-install memcached
+RUN circleci-install rabbitmq
+RUN circleci-install neo4j
+RUN circleci-install elasticsearch
+
+# Browsers
+ADD circleci-provision-scripts/firefox.sh /opt/circleci-provision-scripts/firefox.sh
+RUN circleci-install firefox
+
+ADD circleci-provision-scripts/chrome.sh /opt/circleci-provision-scripts/chrome.sh
+RUN circleci-install chrome
+
+ADD circleci-provision-scripts/phantomjs.sh /opt/circleci-provision-scripts/phantomjs.sh
+RUN circleci-install phantomjs
+
+# Qt
+ADD circleci-provision-scripts/qt.sh /opt/circleci-provision-scripts/qt.sh
+RUN circleci-install qt
+
+# awscli
+ADD circleci-provision-scripts/awscli.sh /opt/circleci-provision-scripts/awscli.sh
+RUN circleci-install awscli

--- a/Dockerfile.dotcom
+++ b/Dockerfile.dotcom
@@ -1,0 +1,70 @@
+FROM circleci/build-image:base
+
+# Languages
+ENV USE_PRECOMPILE true
+RUN curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | sudo bash
+
+ADD circleci-provision-scripts/python.sh /opt/circleci-provision-scripts/python.sh
+RUN circleci-install python 2.7.11
+RUN circleci-install python 3.1.5
+RUN circleci-install python 3.3.6
+RUN circleci-install python 3.5.1
+RUN circleci-install python pypy-1.9
+RUN circleci-install python pypy-2.6.1
+RUN circleci-install python pypy-4.0.1
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; pyenv global 2.7.11"
+
+ADD circleci-provision-scripts/nodejs.sh /opt/circleci-provision-scripts/nodejs.sh
+RUN circleci-install nodejs 0.12.9
+RUN circleci-install nodejs 4.0.0
+RUN circleci-install nodejs 4.1.2
+RUN circleci-install nodejs 4.2.6
+RUN circleci-install nodejs 5.0.0
+RUN circleci-install nodejs 5.1.1
+RUN circleci-install nodejs 5.2.0
+RUN circleci-install nodejs 5.4.1
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; nvm alias default 4.2.6"
+
+ADD circleci-provision-scripts/java.sh /opt/circleci-provision-scripts/java.sh
+RUN circleci-install java
+
+ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
+RUN circleci-install golang 1.5.2
+
+ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
+RUN circleci-install ruby 2.0.0-p647
+RUN circleci-install ruby 2.1.8
+RUN circleci-install ruby 2.2.4
+RUN circleci-install ruby 2.3.0
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; rvm use 2.2.4 --default"
+
+ADD circleci-provision-scripts/php.sh /opt/circleci-provision-scripts/php.sh
+RUN circleci-install php 5.5.31
+RUN circleci-install php 5.6.17
+RUN circleci-install php 7.0.2
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; phpenv global 5.6.17"
+
+ADD circleci-provision-scripts/clojure.sh /opt/circleci-provision-scripts/clojure.sh
+RUN circleci-install clojure
+
+ADD circleci-provision-scripts/scala.sh /opt/circleci-provision-scripts/scala.sh
+RUN circleci-install scala
+
+# Docker have be last - to utilize cache better
+ADD circleci-provision-scripts/docker.sh /opt/circleci-provision-scripts/docker.sh
+RUN circleci-install docker
+RUN circleci-install docker_compose
+
+# When running in unprivileged containers, need to use CircleCI Docker fork
+ARG TARGET_UNPRIVILEGED_LXC
+RUN if [ "$TARGET_UNPRIVILEGED_LXC" = "true" ]; then circleci-install circleci_docker; fi
+
+# Undivert upstart
+# You shouldn't change the line unless you understad the consequence
+RUN rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl
+
+LABEL circleci.user="ubuntu"

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -1,0 +1,66 @@
+FROM circleci/build-image:base
+
+# Languages
+ENV USE_PRECOMPILE false
+RUN curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | sudo bash
+
+ADD circleci-provision-scripts/python.sh /opt/circleci-provision-scripts/python.sh
+RUN circleci-install python 2.7.11
+RUN circleci-install python 3.1.5
+RUN circleci-install python 3.3.6
+RUN circleci-install python 3.5.1
+RUN circleci-install python pypy-1.9
+RUN circleci-install python pypy-2.6.1
+RUN circleci-install python pypy-4.0.1
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; pyenv global 2.7.11"
+
+ADD circleci-provision-scripts/nodejs.sh /opt/circleci-provision-scripts/nodejs.sh
+RUN circleci-install nodejs 0.12.9
+RUN circleci-install nodejs 4.0.0
+RUN circleci-install nodejs 4.1.2
+RUN circleci-install nodejs 4.2.6
+RUN circleci-install nodejs 5.0.0
+RUN circleci-install nodejs 5.1.1
+RUN circleci-install nodejs 5.2.0
+RUN circleci-install nodejs 5.4.1
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; nvm alias default 4.2.6"
+
+ADD circleci-provision-scripts/java.sh /opt/circleci-provision-scripts/java.sh
+RUN circleci-install java
+
+ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
+RUN circleci-install golang 1.5.2
+
+ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
+RUN circleci-install ruby 2.0.0-p647
+RUN circleci-install ruby 2.1.8
+RUN circleci-install ruby 2.2.4
+RUN circleci-install ruby 2.3.0
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; rvm use 2.2.4 --default"
+
+ADD circleci-provision-scripts/php.sh /opt/circleci-provision-scripts/php.sh
+RUN circleci-install php 5.5.31
+RUN circleci-install php 5.6.17
+RUN circleci-install php 7.0.2
+# TODO: make this more robust
+RUN sudo -H -u ubuntu bash -c "source ~/.circlerc; phpenv global 5.6.17"
+
+ADD circleci-provision-scripts/clojure.sh /opt/circleci-provision-scripts/clojure.sh
+RUN circleci-install clojure
+
+ADD circleci-provision-scripts/scala.sh /opt/circleci-provision-scripts/scala.sh
+RUN circleci-install scala
+
+# Docker have be last - to utilize cache better
+ADD circleci-provision-scripts/docker.sh /opt/circleci-provision-scripts/docker.sh
+RUN circleci-install docker
+RUN circleci-install docker_compose
+
+# Undivert upstart
+# You shouldn't change the line unless you understad the consequence
+RUN rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl
+
+LABEL circleci.user="ubuntu"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+IMAGE_SCRATCH := circleci/build-image:scratch
+
+IMAGE_BASE := circleci/build-image:base
+
+IMAGE_DOTCOM := circleci/build-image:dotcom
+
+IMAGE_ENTERPRISE := circleci/build-image:enterprise
+
+default: dotcom enterprise
+
+base:
+	docker pull $(IMAGE_BASE) || true
+	docker build -f Dockerfile.base -t $(IMAGE_SCRATCH) .
+	docker push $(IMAGE_SCRATCH)
+	docker tag $(IMAGE_SCRATCH) $(IMAGE_BASE)
+
+dotcom: base
+	docker pull $(IMAGE_DOTCOM) || true
+	docker build -f Dockerfile.dotcom -t $(IMAGE_DOTCOM) .
+	docker push $(IMAGE_DOTCOM)
+
+enterprise: base
+	docker pull $(IMAGE_ENTERPRISE) || true
+	docker build -f Dockerfile.enterprise -t $(IMAGE_ENTERPRISE) .
+	docker push $(IMAGE_ENTERPRISE)
+
+deploy_dotcom:
+	./docker-export $(IMAGE_DOTCOM) | aws s3 cp - s3://circle-downloads/trusty-beta-$(TAG).tar.gz --acl public-read

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,9 @@ machine:
   environment:
     IMAGE_TAG: 0.0.${CIRCLE_BUILD_NUM}
 
+  pre:
+    - echo 'build_target() { git show | grep $1 > /dev/null; }' >> ~/.circlerc
+
   post:
     - sudo curl -L -o /usr/bin/docker 'https://s3.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
     - sudo service docker start
@@ -12,38 +15,20 @@ dependencies:
 
 test:
   override:
-    # Scratch is the latest cache
-    - docker pull circleci/build-image:scratch || true:
-        timeout: 3600
-
-    - docker build -t circleci/build-image:scratch .:
-        timeout: 3600
-
-    - docker tag circleci/build-image:scratch circleci/build-image:trusty-${IMAGE_TAG}
-
-    - docker push circleci/build-image:scratch:
-        timeout: 3600
-
-    - docker push circleci/build-image:trusty-${IMAGE_TAG}
-
-    # Build a slightly modified image for unprivileged lxc
-    - docker pull circleci/build-image:scratch-unprivileged || true:
-        timeout: 3600
-
-    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true --build-arg use_precompile=true -t circleci/build-image:scratch-unprivileged .:
-        timeout: 3600
-
-    - docker tag circleci/build-image:scratch-unprivileged circleci/build-image:trusty-${IMAGE_TAG}-unprivileged
-
-    - docker push circleci/build-image:scratch-unprivileged:
-        timeout: 3600
-
-    - docker push circleci/build-image:trusty-${IMAGE_TAG}-unprivileged:
+    - ? |
+        if build_target "enterprise"; then
+          make enterprise;
+        elif build_target "dotcom"; then
+          make dotcom;
+        else
+          echo "<<<<<< NO BUILD TARGET SPECIFIED >>>>>>>";
+        fi
+      :
         timeout: 3600
 
 deployment:
   release:
     tag: /\d\d\.\d\d\.\d\d/
     commands:
-      - ./docker-export circleci/build-image:scratch-unprivileged | aws s3 cp - s3://circle-downloads/trusty-beta-${CIRCLE_TAG}.tar.gz --acl public-read:
+      - make dotcom_deployment:
           timeout: 3600


### PR DESCRIPTION
The build time is getting painful slowly to build image for dotcom. We don't have to create both enterprise and dotcom image at the same time, so it makes sense to run the separate builds.