### PR TITLE
Fix build image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use our published containers as your base.
 For doing so, you can create a Dockerfile with the appropriate customizations:
 
 ```
-FROM circleci/ubuntu-server:trusty-latest
+FROM circleci/build-image:latest
 
 # You can use some basic tools, using the `circleci-install` helper function
 # for tools, CircleCI supports


### PR DESCRIPTION
This was pointing to the image that requires having a copy of this repository to access circleci-install.