### PR TITLE
Use a PPA for git, `xargs apt-get install` less

### DIFF
--- a/circleci-provision-scripts/base.sh
+++ b/circleci-provision-scripts/base.sh
@@ -45,6 +45,9 @@ EOF
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get update -y
+    apt-get install -y software-properties-common
+    apt-get update -y
+    apt-add-repository ppa:git-core/ppa
 
     # Install base packages
     cat << EOS | xargs apt-get install
@@ -64,7 +67,6 @@ make
 mercurial
 parallel
 protobuf-compiler
-software-properties-common
 sysv-rc-conf
 unzip
 zip

--- a/circleci-provision-scripts/base.sh
+++ b/circleci-provision-scripts/base.sh
@@ -50,7 +50,7 @@ EOF
     apt-add-repository ppa:git-core/ppa
 
     # Install base packages
-    cat << EOS | xargs apt-get install
+    apt-get install $(tr '\n' ' ' <<EOS
 autoconf
 bsdtar
 build-essential
@@ -71,4 +71,5 @@ sysv-rc-conf
 unzip
 zip
 EOS
+)
 }

--- a/circleci-provision-scripts/misc.sh
+++ b/circleci-provision-scripts/misc.sh
@@ -40,13 +40,11 @@ function install_elasticsearch() {
 
 
 function install_sysadmin() {
-    cat << EOS | xargs apt-get install
-htop
-EOS
+    apt-get install htop
 }
 
 function install_devtools() {
-    cat << EOS | xargs apt-get install
+    apt-get install $(tr '\n' ' ' <<EOS
 ack-grep
 emacs
 gdb
@@ -56,6 +54,7 @@ tmux
 vim
 vnc4server
 EOS
+)
 }
 
 function install_closure() {


### PR DESCRIPTION
We want to have 2.7.4 for https://ma.ttias.be/remote-code-execution-git-versions-client-server-2-7-1-cve-2016-2324-cve-2016-2315/ , since that fix doesn't seem to have been backported yet.

Also, `xargs apt-get install` is slow, so let's do that less.