### PR TITLE
pulling latest unprivileged doesn't help

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,9 +36,6 @@ test:
     - docker push circleci/build-image:trusty-${IMAGE_TAG}
 
     # Build a slightly modified image for unprivileged lxc
-    - docker pull circleci/build-image:scratch-unprivileged || true:
-        timeout: 3600
-
     - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true -t circleci/build-image:scratch-unprivileged .:
         timeout: 3600
 


### PR DESCRIPTION
Pulling latest unprivileged doesn't help with docker caching - as the privileged just recently built image has all the layers we care about.