### PR TITLE
Fix docker version

### DIFF
--- a/circleci-provision-scripts/docker.sh
+++ b/circleci-provision-scripts/docker.sh
@@ -3,8 +3,10 @@
 function install_docker() {
     echo '>>>> Installing Docker'
 
-    # Install Docker
-    curl -L -s https://get.docker.io/ | sh
+    # Pin Docker version to 10.x since 11 brings breaking changes
+    echo "deb [arch=amd64] https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
+    apt-get update
+    apt-get install docker-engine=1.10.3-0~trusty
 
     # Devicemapper files are huge if got created - we don't use device mapper anyway
     rm -rf /var/lib/docker/devicemapper/devicemapper/data

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,5 @@
-FROM circleci/build-image:scratch
+FROM circleci/build-image:scratch-unprivileged
 
 ADD insecure-ssh-key.pub /home/ubuntu/.ssh/authorized_keys
 RUN chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys
 RUN git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh /usr/local
-

--- a/tests/unit/services.bats
+++ b/tests/unit/services.bats
@@ -108,3 +108,11 @@ wait_service () {
 
     [ "$status" -eq 0 ]
 }
+
+# We just run `docker version` without running actual daemon
+# because docker can't run inside docker (DIND)
+@test "circleci docker is installed" {
+    run bash -c 'docker version | grep Version | grep circleci'
+
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/services.bats
+++ b/tests/unit/services.bats
@@ -24,53 +24,53 @@ wait_service () {
 @test "mysql is enabled by default" {
     run test_enabled_default "mysql"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "mysql works" {
     run mysql -e "STATUS;"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "postgresql is enabled by default" {
     run sudo service postgresql status
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "postgresql works" {
     run psql -c "SELECT version();"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "mongodb is enabled by default" {
     run test_enabled_default "mongod"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "mongodb works" {
-    run echo 'show dbs;' | mongo
+    run bash -c "echo 'show dbs;' | mongo"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "redis works" {
     sudo service redis-server start
 
-    run echo "SET hoge bar" | redis-cli
+    run bash -c "echo 'SET hoge bar' | redis-cli"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "memcached works" {
     sudo service memcached start
 
-    run echo stats | nc localhost 11211
+    run bash -c "echo stats | nc localhost 11211"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "neo4j works" {
@@ -78,7 +78,7 @@ wait_service () {
 
     run neo4j-shell -c "mknode --cd"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "rabbitmq works" {
@@ -86,7 +86,7 @@ wait_service () {
 
     run sudo rabbitmqctl cluster_status
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "elasticsearch works" {
@@ -98,13 +98,13 @@ wait_service () {
 
     run curl http://localhost:$port
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }
 
 @test "beanstalkd works" {
     sudo service beanstalkd start
 
-    run echo -e "stats\r\n" | nc localhost 11300
+    run bash -c "echo -e 'stats\r\n' | nc localhost 11300"
 
-    [[ "$status" -eq 0 ]]
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
`curl -L -s https://get.docker.io/ | sh` will install the latest docker and breaks upstart scripts that circleci docker relies on.