### PR TITLE
Changing workflow2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,14 @@ ADD circleci-install /usr/local/bin/circleci-install
 
 ADD circleci-provision-scripts/base.sh /opt/circleci-provision-scripts/base.sh
 ADD circleci-provision-scripts/circleci-specific.sh /opt/circleci-provision-scripts/circleci-specific.sh
-RUN circleci-install base_requirements  && circleci-install circleci_specific
+RUN circleci-install base_requirements && circleci-install circleci_specific
 
 # Databases
 ADD circleci-provision-scripts/mysql.sh /opt/circleci-provision-scripts/mysql.sh
-RUN circleci-install mysql_56
-
 ADD circleci-provision-scripts/mongo.sh /opt/circleci-provision-scripts/mongo.sh
-RUN circleci-install mongo
-
 ADD circleci-provision-scripts/postgres.sh /opt/circleci-provision-scripts/postgres.sh
-RUN circleci-install postgres
-RUN circleci-install postgres_ext_postgis
+RUN circleci-install mysql_56 && circleci-install mongo
+RUN circleci-install postgres && circleci-install postgres_ext_postgis
 
 # Installing java early beacuse a few things have the dependency to java (i.g. cassandra)
 ADD circleci-provision-scripts/java.sh /opt/circleci-provision-scripts/java.sh
@@ -38,13 +34,9 @@ RUN for s in apache2 redis-server memcached rabbitmq-server neo4j neo4j-service 
 
 # Browsers
 ADD circleci-provision-scripts/firefox.sh /opt/circleci-provision-scripts/firefox.sh
-RUN circleci-install firefox
-
 ADD circleci-provision-scripts/chrome.sh /opt/circleci-provision-scripts/chrome.sh
-RUN circleci-install chrome
-
 ADD circleci-provision-scripts/phantomjs.sh /opt/circleci-provision-scripts/phantomjs.sh
-RUN circleci-install phantomjs
+RUN circleci-install firefox && circleci-install chrome && circleci-install phantomjs
 
 # Android
 ADD circleci-provision-scripts/android-sdk.sh /opt/circleci-provision-scripts/android-sdk.sh
@@ -147,8 +139,7 @@ RUN circleci-install scala
 
 # Docker have be last - to utilize cache better
 ADD circleci-provision-scripts/docker.sh /opt/circleci-provision-scripts/docker.sh
-RUN circleci-install docker
-RUN circleci-install docker_compose
+RUN circleci-install docker && circleci-install docker_compose
 
 # When running in unprivileged containers, need to use CircleCI Docker fork
 ARG TARGET_UNPRIVILEGED_LXC

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,9 @@ ADD circleci-provision-scripts /opt/circleci-provision-scripts
 
 ADD Dockerfile /opt/circleci/Dockerfile
 
+ARG IMAGE_TAG
+RUN echo $IMAGE_TAG > /opt/circleci/image_version
+
 ADD pkg-versions.sh /opt/circleci/bin/pkg-versions.sh
 RUN sudo -H -i -u ubuntu bash -c "/opt/circleci/bin/pkg-versions.sh | jq . > /opt/circleci/versions.json"
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   environment:
-    IMAGE_TAG: 0.0.${CIRCLE_BUILD_NUM}
+    IMAGE_TAG: trusty-${CIRCLE_BUILD_NUM}-$(cd $CIRCLE_PROJECT_REPONAME && git rev-parse --short HEAD)
+    IMAGE_REPO: "circleci/build-image"
 
   pre:
     - echo 'no_cache() { git log --format=%B -n 1 | grep -q "no cache"; }' >> ~/.circlerc
@@ -12,40 +13,41 @@ machine:
 
 dependencies:
   override:
+    - echo "Building Docker image $IMAGE_REPO:$IMAGE_TAG"
     - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 
     # Scratch is the latest cache
-    - docker pull circleci/build-image:scratch || true:
+    - docker pull ${IMAGE_REPO}:scratch || true:
         timeout: 3600
 
     - ? |
         if $(no_cache); then
-          docker build --no-cache -t circleci/build-image:scratch .;
+          docker build --no-cache --build-arg IMAGE_TAG=${IMAGE_TAG} -t ${IMAGE_REPO}:scratch .;
         else
-          docker build -t circleci/build-image:scratch .;
+          docker build --build-arg IMAGE_TAG=${IMAGE_TAG} -t ${IMAGE_REPO}:scratch .;
         fi
       :
         timeout: 3600
 
-    - docker run circleci/build-image:scratch cat /opt/circleci/versions.json > $CIRCLE_ARTIFACTS/versions.json
+    - docker run ${IMAGE_REPO}:scratch cat /opt/circleci/versions.json > $CIRCLE_ARTIFACTS/versions.json
 
-    - docker tag circleci/build-image:scratch circleci/build-image:trusty-${IMAGE_TAG}
+    - docker tag ${IMAGE_REPO}:scratch ${IMAGE_REPO}:${IMAGE_TAG}
 
-    - docker-push-with-retry circleci/build-image:scratch:
+    - docker-push-with-retry ${IMAGE_REPO}:scratch:
         timeout: 3600
 
-    - docker-push-with-retry circleci/build-image:trusty-${IMAGE_TAG}
+    - docker-push-with-retry ${IMAGE_REPO}:${IMAGE_TAG}
 
     # Build a slightly modified image for unprivileged lxc
-    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true -t circleci/build-image:scratch-unprivileged .:
+    - docker build --build-arg TARGET_UNPRIVILEGED_LXC=true --build-arg IMAGE_TAG=${IMAGE_TAG} -t ${IMAGE_REPO}:scratch-unprivileged .:
         timeout: 3600
 
-    - docker tag circleci/build-image:scratch-unprivileged circleci/build-image:trusty-${IMAGE_TAG}-unprivileged
+    - docker tag ${IMAGE_REPO}:scratch-unprivileged ${IMAGE_REPO}:${IMAGE_TAG}-unprivileged
 
-    - docker-push-with-retry circleci/build-image:scratch-unprivileged:
+    - docker-push-with-retry ${IMAGE_REPO}:scratch-unprivileged:
         timeout: 3600
 
-    - docker-push-with-retry circleci/build-image:trusty-${IMAGE_TAG}-unprivileged:
+    - docker-push-with-retry ${IMAGE_REPO}:${IMAGE_TAG}-unprivileged:
         timeout: 3600
 
 test:
@@ -57,12 +59,8 @@ test:
     - sleep 10; chmod 600 tests/insecure-ssh-key; ssh -i tests/insecure-ssh-key -p 12345 ubuntu@localhost bats tests/unit
 
 deployment:
-  release:
-    tag: /\d\d\.\d\d\.\d\d/
+  production:
+    branch: master
     commands:
-      - docker tag circleci/build-image:scratch circleci/build-image:trusty-enterprise-${CIRCLE_TAG}
-      - docker tag circleci/build-image:scratch-unprivileged circleci/build-image:trusty-dotcom-${CIRCLE_TAG}
-      - docker-push-with-retry circleci/build-image:trusty-enterprise-${CIRCLE_TAG}
-      - docker-push-with-retry circleci/build-image:trusty-dotcom-${CIRCLE_TAG}
-      - ./docker-export circleci/build-image:trusty-dotcom-${CIRCLE_TAG} | aws s3 cp - s3://circle-downloads/trusty-dotcom-${CIRCLE_TAG}.tar.gz --acl public-read:
+      - ./docker-export ${IMAGE_REPO}:${IMAGE_TAG}-unprivileged | aws s3 cp - s3://circle-downloads/build-image-$IMAGE_TAG.tar.gz --acl public-read:
           timeout: 3600

--- a/pkg-versions.sh
+++ b/pkg-versions.sh
@@ -40,6 +40,7 @@ all_php() {
 cat<<EOF
 {
   "summary": {
+    "build-image": "$(cat /opt/circleci/image_version)",
     "google-chrome": "$(google-chrome --version | col 3)",
     "chromedriver": "$(chromedriver --version | col 2)",
     "firefox": "$(firefox --version | col 3)",


### PR DESCRIPTION
The motivation here is stop using Github release tag to push LXC image because it doesn't fit into how we test container image.

**Before**
- build docker image at master
- pull the docker image locally
- once the image fines, create Github release that triggers a build
- the build will push LXC image to S3 which will be shipped to production

The problem here is that there is no guarantee that the build image created by Github release is exactly the same as the image that's already tested. In practice, it will be the same image thanks to Docker cache, but still not guaranteed.

**After**
- build docker image at master
- push LXC image to S3
- pull the docker image locally
- once the image fines, ship the LXC image to production