### PR TITLE
Always running apt-get update for packagecloud repository

### DIFF
--- a/circleci-provision-scripts/nodejs.sh
+++ b/circleci-provision-scripts/nodejs.sh
@@ -71,6 +71,7 @@ EOF
 function install_nodejs_version_precompile() {
     local NODEJS_VERSION=$1
 
+    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
     apt-get install circleci-nodejs-$NODEJS_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/nodejs
     set_nodejs_default $NODEJS_VERSION

--- a/circleci-provision-scripts/php.sh
+++ b/circleci-provision-scripts/php.sh
@@ -68,7 +68,8 @@ function install_php_version_precompile() {
     local PHP_VERSION=$1
     echo ">>> Installing php $PHP_VERSION"
 
-    apt-get update; apt-get install circleci-php-$PHP_VERSION
+    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
+    apt-get install circleci-php-$PHP_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/php
 }
 

--- a/circleci-provision-scripts/python.sh
+++ b/circleci-provision-scripts/python.sh
@@ -49,6 +49,7 @@ EOF
 function install_python_version_precompile() {
     local PYTHON_VERSION=$1
 
+    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
     apt-get install circleci-python-$PYTHON_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/python
 }

--- a/circleci-provision-scripts/ruby.sh
+++ b/circleci-provision-scripts/ruby.sh
@@ -77,6 +77,7 @@ function install_ruby_version_precompile() {
     local INSTALL_RUBY_VERSION=$1
     echo ">>> Installing Ruby $INSTALL_RUBY_VERSION"
 
+    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
     apt-get install circleci-ruby-$INSTALL_RUBY_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/ruby/
 


### PR DESCRIPTION
This is necessary otherwise we need to build the image from scratch when we add a new version of language because `apt-get upadte` for packagecloud is cached and doesn't detect newly created version.