### PR TITLE
Postgresql 9.5

### DIFF
--- a/circleci-provision-scripts/postgres.sh
+++ b/circleci-provision-scripts/postgres.sh
@@ -6,7 +6,7 @@ function install_postgres_ext_postgis() {
     local DIR=geos-${VERSION}
     local URL=http://download.osgeo.org/geos/${FILE}
 
-    apt-get install ruby-dev swig swig2.0 postgis postgresql-9.4-postgis-2.1
+    apt-get install ruby-dev swig swig2.0 postgis postgresql-9.5-postgis-2.2
 
     # Install GEOS
     pushd /tmp
@@ -27,7 +27,7 @@ function install_postgres_ext_postgis() {
 }
 
 function install_postgres() {
-    POSTGRES_VERSION=9.4
+    POSTGRES_VERSION=9.5
 
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 

--- a/pkg-versions.sh
+++ b/pkg-versions.sh
@@ -50,7 +50,7 @@ cat<<EOF
     "chromedriver": "$(chromedriver --version | col 2)",
     "firefox": "$(firefox --version | col 3)",
     "mongod": "$(mongod --version | grep 'db version' | col 3 | sed 's/^v//')",
-    "psql": "$(psql --version | grep psql | col 3)",
+    "psql": "$(/usr/lib/postgresql/9.5/bin/postgres --version | col 3)",
     "mysqld": "$(mysql --version | col 6 | sed 's/,//')",
     "ruby": {
       "default": "$(ruby --version | cut -d " " -f 2)",


### PR DESCRIPTION
We were installing both 9.4 and 9.5 on the Trusty container image but this has never been our intention. 9.4 is the version that we wanted to install but 9.5 was also installed as a part of postgis dependency.

It looks majority of our customers want 9.5, though. So, we'll be updating to 9.5 and not to install 9.4 at all.
