### PR TITLE
MySQL 5.7 empty root password

### DIFF
--- a/circleci-provision-scripts/mysql.sh
+++ b/circleci-provision-scripts/mysql.sh
@@ -67,5 +67,13 @@ function install_mysql_57() {
 
     apt-get -y install mysql-server-5.7 libmysqld-dev
 
+    # root password is set only for socket but not for network during the installation.
+    # See: https://www.percona.com/blog/2016/03/16/change-user-password-in-mysql-5-7-with-plugin-auth_socket/
+    mysqld &
+    sleep 5
+    mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';"
+    sleep 5
+    pkill -9 mysqld
+
     configure_mysql
 }

--- a/tests/unit/services.bats
+++ b/tests/unit/services.bats
@@ -53,6 +53,10 @@ create_postgis_extention () {
     [ "$status" -eq 0 ]
 }
 
+@test "mysql: root password is empty" {
+    run mysql -u root -e 'STATUS;'
+}
+
 @test "postgresql: enabled by default" {
     run sudo service postgresql status
 


### PR DESCRIPTION
Updating mysql to 5.7 break some builds because empty password for root is set only for socket but not for network access. See https://www.percona.com/blog/2016/03/16/change-user-password-in-mysql-5-7-with-plugin-auth_socket/