### PR TITLE
Fix redis not starting up and staying up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ADD circleci-provision-scripts/misc.sh /opt/circleci-provision-scripts/misc.sh
 RUN for package in sysadmin devtools jq redis memcached rabbitmq neo4j elasticsearch beanstalkd cassandra riak couchdb; do circleci-install $package; done
 
 # Dislabe services by default
-RUN for s in apache2 redis-server memcached rabbitmq-server neo4j neo4j-service elasticsearch beanstalkd cassandra riak couchdb; do sysv-rc-conf $s off; done
+RUN for s in apache2 memcached rabbitmq-server neo4j neo4j-service elasticsearch beanstalkd cassandra riak couchdb; do sysv-rc-conf $s off; done
 
 # Browsers
 ADD circleci-provision-scripts/firefox.sh /opt/circleci-provision-scripts/firefox.sh

--- a/circleci-provision-scripts/misc.sh
+++ b/circleci-provision-scripts/misc.sh
@@ -2,6 +2,13 @@
 
 function install_redis() {
     apt-get install redis-server
+    # disable init.d script for redis
+    update-rc.d redis-server disable
+    rm /etc/init.d/redis-server
+    # manage redis with upsatart. needs to be explicitly started with 'sudo start redis-server'
+    printf 'description "redis server"\nstop on shutdown\nexec sudo -u redis /usr/bin/redis-server /etc/redis/redis.conf\nrespawn' > /etc/init/redis-server.conf
+    # prevent redis-server from forking and daemonizing itself so upstart can respawn it
+    sed -i "s|daemonize yes|daemonize no|g" /etc/redis/redis.conf
 }
 
 function install_memcached() {


### PR DESCRIPTION
After some testing on my own builds I'm reasonably confident that this fixes the issue with Redis not starting up and staying up on 14.04.

Various searches suggest that getting Upstart to manage Redis in 14.04 is the most reliable option. The specific source for the changes I've made is here: https://gist.github.com/bdotdub/714533

