### PR TITLE
Add RUN_APT_UPDATE flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ RUN for package in awscli gcloud heroku; do circleci-install $package; done
 # Languages
 ARG use_precompile=true
 ENV USE_PRECOMPILE $use_precompile
+ENV RUN_APT_UPDATE=true
 RUN curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | sudo bash
-
 ADD circleci-provision-scripts/python.sh /opt/circleci-provision-scripts/python.sh
 RUN circleci-install python 2.7.10
 RUN circleci-install python 2.7.11

--- a/circleci-install
+++ b/circleci-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 [ -n "$CIRCLECI_USER" ] || export CIRCLECI_USER=ubuntu
+[ -n "$RUN_APT_UPDATE" ] || export RUN_APT_UPDATE=false
+
 export CIRCLECI_HOME=/home/${CIRCLECI_USER}
 export CIRCLECI_PKG_DIR=/opt/circleci
 
@@ -15,6 +17,12 @@ function as_user() {
 }
 export -f as_user
 
+function maybe_run_apt_update() {
+    if [ $RUN_APT_UPDATE = "true" ]; then
+	apt-get update
+    fi
+}
+export -f maybe_run_apt_update
 
 [[ $SCRIPTS_PATH ]] || export SCRIPTS_PATH=/opt/circleci-provision-scripts
 

--- a/circleci-provision-scripts/nodejs.sh
+++ b/circleci-provision-scripts/nodejs.sh
@@ -71,7 +71,7 @@ EOF
 function install_nodejs_version_precompile() {
     local NODEJS_VERSION=$1
 
-    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
+    maybe_run_apt_update
     apt-get install circleci-nodejs-$NODEJS_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/nodejs
     set_nodejs_default $NODEJS_VERSION

--- a/circleci-provision-scripts/php.sh
+++ b/circleci-provision-scripts/php.sh
@@ -68,7 +68,7 @@ function install_php_version_precompile() {
     local PHP_VERSION=$1
     echo ">>> Installing php $PHP_VERSION"
 
-    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
+    maybe_run_apt_update
     apt-get install circleci-php-$PHP_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/php
 }

--- a/circleci-provision-scripts/python.sh
+++ b/circleci-provision-scripts/python.sh
@@ -49,7 +49,7 @@ EOF
 function install_python_version_precompile() {
     local PYTHON_VERSION=$1
 
-    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
+    maybe_run_apt_update
     apt-get install circleci-python-$PYTHON_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/python
 }

--- a/circleci-provision-scripts/ruby.sh
+++ b/circleci-provision-scripts/ruby.sh
@@ -77,7 +77,7 @@ function install_ruby_version_precompile() {
     local INSTALL_RUBY_VERSION=$1
     echo ">>> Installing Ruby $INSTALL_RUBY_VERSION"
 
-    curl -s https://packagecloud.io/install/repositories/circleci/trusty/script.deb.sh | bash
+    maybe_run_apt_update
     apt-get install circleci-ruby-$INSTALL_RUBY_VERSION
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/ruby/
 


### PR DESCRIPTION
We want to avoid expensive apt-get update to install a version when `circleci-install` is used standalone.