### PR TITLE
Use xtrace (-x) shellopts only when VERBOSE=true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM circleci/ubuntu-server:trusty-latest
 
+ENV VERBOSE true
+
 # Avoid any installation scripts interact with upstart
 # So divert now, but undivert at the end
 # You shouldn't change the line unless you understand the consequence

--- a/circleci-install
+++ b/circleci-install
@@ -19,10 +19,18 @@ export -f as_user
 [[ $SCRIPTS_PATH ]] || export SCRIPTS_PATH=/opt/circleci-provision-scripts
 
 set -a
+set -e
+
+if [ "$VERBOSE" = "true" ]; then
+  echo "enabling debug mode...."
+  set -x
+fi
+
+export SHELLOPTS
+
 for n in $SCRIPTS_PATH/*.sh
 do
     source $n
 done
 
-set -ex
 install_$@

--- a/circleci-provision-scripts/android-ndk.sh
+++ b/circleci-provision-scripts/android-ndk.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -ex
 
 function install_ndk() {
     NDK_VERSION=r10d

--- a/circleci-provision-scripts/android-sdk.sh
+++ b/circleci-provision-scripts/android-sdk.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -ex
 
 function install_circle_android_helper() {
     cat <<'EOF' > /usr/local/bin/circle-android

--- a/circleci-provision-scripts/clojure.sh
+++ b/circleci-provision-scripts/clojure.sh
@@ -10,8 +10,7 @@ function install_clojure() {
 
     (cat <<'EOF'
 # Force dependencies to download
-set -ex
 lein -v
 EOF
-    ) | as_user bash    
+    ) | as_user bash
 }

--- a/circleci-provision-scripts/nodejs.sh
+++ b/circleci-provision-scripts/nodejs.sh
@@ -7,8 +7,6 @@ function install_nvm() {
 
     echo 'Install NVM'
     (cat <<'EOF'
-set -ex
-
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | NVM_DIR=$CIRCLECI_PKG_DIR/.nvm bash
 echo "export NVM_DIR=$CIRCLECI_PKG_DIR/.nvm" >> ~/.circlerc
 echo 'source $NVM_DIR/nvm.sh' >> ~/.circlerc
@@ -20,7 +18,6 @@ EOF
 
         # Preparing for hooking up packaged NodeJS into nvm directories
         (cat <<'EOF'
-set -ex
 mkdir $CIRCLECI_PKG_DIR/nodejs
 EOF
         ) | as_user CIRCLECI_PKG_DIR=$CIRCLECI_PKG_DIR bash
@@ -44,7 +41,6 @@ function patch_nvm() {
 function install_nodejs_version_nvm() {
     NODEJS_VERSION=$1
     (cat <<'EOF'
-set -ex
 source ~/.circlerc
 nvm install $NODEJS_VERSION
 rm -rf ~/nvm/src
@@ -91,7 +87,6 @@ function set_nodejs_default() {
     local NODEJS_VERSION=$1
 
     (cat <<'EOF'
-set -ex
 source ~/.circlerc
 nvm alias default $NODEJS_VERSION
 EOF

--- a/circleci-provision-scripts/php.sh
+++ b/circleci-provision-scripts/php.sh
@@ -14,8 +14,6 @@ function install_phpenv(){
 
     echo '>>> Installing php-env and php-build'
     (cat <<'EOF'
-set -ex
-
 # Because of https://github.com/phpenv/phpenv/issues/43 I can't install from git directly
 curl -L https://raw.github.com/CHH/phpenv/master/bin/phpenv-install.sh | bash
 mv ~/.phpenv $CIRCLECI_PKG_DIR
@@ -29,7 +27,6 @@ EOF
     if [ -n "$USE_PRECOMPILE" ]; then
         # Preparing for hooking up packaged Python into pyenv directories
         (cat <<'EOF'
-set -ex
 mkdir $CIRCLECI_PKG_DIR/php
 ln -s $CIRCLECI_PKG_DIR/php $CIRCLECI_PKG_DIR/.phpenv/versions
 EOF
@@ -57,7 +54,6 @@ function install_php_version_phpenv() {
     echo ">>> Installing php $PHP_VERSION"
 
     (cat <<'EOF'
-set -ex
 source ~/.circlerc
 phpenv install $PHP_VERSION
 EOF

--- a/circleci-provision-scripts/postgres.sh
+++ b/circleci-provision-scripts/postgres.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Temporarly disable errexit to avoid a strange test error during make.
+set +o errexit
+
 function install_postgres_ext_postgis() {
     local VERSION=3.5.0
     local FILE=geos-${VERSION}.tar.bz2
@@ -14,8 +17,10 @@ function install_postgres_ext_postgis() {
     tar -jxf $FILE
     cd $DIR
     ./configure --enable-ruby "--prefix=/usr"
+
     make &> "/tmp/goes.log"
     make install
+
     popd
 
     rm -rf /tmp/*

--- a/circleci-provision-scripts/python.sh
+++ b/circleci-provision-scripts/python.sh
@@ -12,7 +12,6 @@ function install_pyenv() {
 
     echo 'Installing pyenv'
     (cat <<'EOF'
-set -ex
 git clone https://github.com/yyuu/pyenv.git $CIRCLECI_PKG_DIR/.pyenv
 echo "export PYENV_ROOT=$CIRCLECI_PKG_DIR/.pyenv" >> ~/.circlerc
 echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> ~/.circlerc
@@ -23,7 +22,6 @@ EOF
     if [ -n "$USE_PRECOMPILE" ]; then
     # Preparing for hooking up packaged Python into pyenv directories
         (cat <<'EOF'
-set -ex
 mkdir $CIRCLECI_PKG_DIR/python
 ln -s $CIRCLECI_PKG_DIR/python $CIRCLECI_PKG_DIR/.pyenv/versions
 EOF
@@ -34,7 +32,6 @@ EOF
 function install_python_version_pyenv() {
     PYTHON_VERSION=$1
     (cat <<'EOF'
-set -ex
 source ~/.circlerc
 pyenv install $PYTHON_VERSION
 pyenv global $PYTHON_VERSION
@@ -57,7 +54,6 @@ function install_python_version_precompile() {
 function set_python_default() {
     local PYTHON_VERSION=$1
     (cat <<'EOF'
-set -ex
 source ~/.circlerc
 pyenv global $PYTHON_VERSION
 pyenv rehash

--- a/circleci-provision-scripts/ruby.sh
+++ b/circleci-provision-scripts/ruby.sh
@@ -30,7 +30,6 @@ EOF
     ) | as_user tee ${CIRCLECI_HOME}/.gemrc
 
     (cat <<'EOF'
-set -ex
 source ~/.circlerc
 rvm rvmrc warning ignore allGemfiles
 EOF
@@ -40,7 +39,6 @@ EOF
     # Preparing for hooking up packaged Ruby into rvm directories
 
     (cat <<'EOF'
-set -ex
 mkdir $CIRCLECI_PKG_DIR/ruby
 rm -r $CIRCLECI_PKG_DIR/.rvm/rubies
 ln -s $CIRCLECI_PKG_DIR/ruby $CIRCLECI_PKG_DIR/.rvm/rubies
@@ -60,7 +58,6 @@ function install_ruby_version_rvm() {
     INSTALL_RUBY_VERSION=$1
     RUBYGEMS_MAJOR_RUBY_VERSION=${2:-2}
     (cat <<'EOF'
-set -ex
 echo Installing Ruby version: $INSTALL_RUBY_VERSION
 source ~/.circlerc
 rvm use $INSTALL_RUBY_VERSION
@@ -82,7 +79,6 @@ function install_ruby_version_precompile() {
     chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/ruby/
 
     (cat <<'EOF'
-set -ex
 echo Installing Ruby version: $INSTALL_RUBY_VERSION
 source ~/.circlerc
 rvm use $INSTALL_RUBY_VERSION

--- a/circleci-provision-scripts/scala.sh
+++ b/circleci-provision-scripts/scala.sh
@@ -5,8 +5,6 @@ function install_scala() {
     rm sbt-0.13.9.deb
 
     (cat <<'EOF'
-set -ex
-
 # Run sbt once to download dependencies.
 # SBT_OPTS="-XX:MaxMetaspaceSize=384M" sbt -v
 SBT_LAUNCH_VERSIONS="0.13.5 0.13.6 0.13.7 0.13.8 0.13.9"


### PR DESCRIPTION
When using `circleci-install` standalone, the default verbose output is obtrusive, so disabling verbose output by default and can be enabled with `VERBOSE` flag.

Also removing redundant shellopts set in many places and consolidated into once place that we can export to child processes.