### PR TITLE
Update Go version to v1.7.1.

### DIFF
--- a/circleci-provision-scripts/go.sh
+++ b/circleci-provision-scripts/go.sh
@@ -5,12 +5,12 @@ function install_golang() {
 
     echo ">>> Installing Go ${GO_VERSION}"
 
-    URL=http://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
+    URL=https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
 
     curl -sSL -o /tmp/go.tar.gz $URL
     tar -xz -f /tmp/go.tar.gz -C /usr/local
 
-    # Workaround an issue with go install wanting to write to goroot
+    # Workaround an issue with Go install wanting to write to goroot
     # in old versions
     chown ${CIRCLECI_USER}:${CIRCLECI_USER} /usr/local/go
 

--- a/targets/ubuntu-14.04-XL/Dockerfile
+++ b/targets/ubuntu-14.04-XL/Dockerfile
@@ -79,7 +79,7 @@ RUN circleci-install nodejs 6.1.0
 RUN sudo -H -i -u ubuntu nvm alias default 4.2.6
 
 ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
-RUN circleci-install golang 1.6.2
+RUN circleci-install golang 1.7.3
 
 ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
 RUN circleci-install ruby 2.1.8

--- a/targets/ubuntu-14.04-XXL-enterprise/Dockerfile
+++ b/targets/ubuntu-14.04-XXL-enterprise/Dockerfile
@@ -97,7 +97,7 @@ RUN circleci-install nodejs 6.1.0
 RUN sudo -H -i -u ubuntu nvm alias default 4.2.6
 
 ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
-RUN circleci-install golang 1.6.2
+RUN circleci-install golang 1.7.3
 
 ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
 RUN circleci-install ruby 2.1.8

--- a/targets/ubuntu-14.04-XXL/Dockerfile
+++ b/targets/ubuntu-14.04-XXL/Dockerfile
@@ -97,7 +97,7 @@ RUN circleci-install nodejs 6.1.0
 RUN sudo -H -i -u ubuntu nvm alias default 4.2.6
 
 ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
-RUN circleci-install golang 1.6.2
+RUN circleci-install golang 1.7.3
 
 ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
 RUN circleci-install ruby 2.1.8

--- a/targets/ubuntu-14.04-enterprise/Dockerfile
+++ b/targets/ubuntu-14.04-enterprise/Dockerfile
@@ -68,7 +68,7 @@ RUN circleci-install nodejs 6.3.1
 RUN sudo -H -i -u ubuntu nvm alias default 4.2.6
 
 ADD circleci-provision-scripts/go.sh /opt/circleci-provision-scripts/go.sh
-RUN circleci-install golang 1.6.2
+RUN circleci-install golang 1.7.3
 
 ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
 RUN circleci-install ruby 2.1.2


### PR DESCRIPTION
Fixes #95

Bumped the Go version to the latest stable release as well as switched to HTTPS for the download URL.
