### PR TITLE
[WIP] Update Java 8 version to 8u101.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN circleci-install base_requirements && circleci-install circleci_specific
 ADD circleci-provision-scripts/mysql.sh circleci-provision-scripts/mongo.sh circleci-provision-scripts/postgres.sh /opt/circleci-provision-scripts/
 RUN for package in mysql_57 mongo postgres postgres_ext_postgis; do circleci-install $package; done
 
-# Installing java early beacuse a few things have the dependency to java (i.g. cassandra)
+# Installing Java early beacuse a few things have the dependency to Java (i.g. cassandra)
 ADD circleci-provision-scripts/java.sh /opt/circleci-provision-scripts/java.sh
 RUN circleci-install java oraclejdk8 && circleci-install java openjdk8
 

--- a/circleci-provision-scripts/java.sh
+++ b/circleci-provision-scripts/java.sh
@@ -5,8 +5,8 @@ function install_oraclejdk8() {
 
     # We could install java8 with PPA but our inference code expects java to be installed under /usr/lib/jvm
     # so taking old approach here.
-    FILE=jdk-8u40-linux-x64.gz
-    URL="https://circle-downloads.s3.amazonaws.com/jdk-8u40-linux-x64.gz"
+    FILE=jdk-8u101-linux-x64.gz
+    URL="https://circle-downloads.s3.amazonaws.com/jdk-8u101-linux-x64.gz"
     JAVA_TMP=/tmp/java
 
     mkdir -p $JAVA_TMP
@@ -15,7 +15,7 @@ function install_oraclejdk8() {
     curl -L -O $URL
     tar zxf $FILE
     mkdir -p /usr/lib/jvm
-    mv ./jdk1.8.0_40 /usr/lib/jvm/jdk1.8.0
+    mv ./jdk1.8.0_101 /usr/lib/jvm/jdk1.8.0
 
     update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/jdk1.8.0/bin/java" 1
     update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/jdk1.8.0/bin/javac" 1


### PR DESCRIPTION
For this to be merged, we need to upload the Java 8 file to S3: `jdk-8u101-linux-x64.gz`

This updates Java 8 (Oracle) to java8u101.

The two latest versions are java8u101 and java8u102. 101 contains security updates & bug fixes while 102 includes several new features. Aside from being up-to-date is always a good thing, java8u101 contains support for Let's Encrypt TLS certificates which is a growing trend on the web. Would also help this guy: https://discuss.circleci.com/t/using-a-particular-jdk-build/6340
