### PR TITLE
Chown bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 # and services such as MySQL or Redis are installed.
 ###
 build-ubuntu-14.04-XXL:
-	docker-cache-shim pull ${IMAGE_REPO}
+	docker-cache-shim pull ${IMAGE_REPO} || true
 	echo "Building Docker image ubuntu-14.04-XXL-$(VERSION)"
 	docker build $(NO_CACHE) --build-arg IMAGE_TAG=ubuntu-14.04-XXL-$(VERSION) \
 	-t $(IMAGE_REPO):ubuntu-14.04-XXL-$(VERSION) \
@@ -52,7 +52,7 @@ ubuntu-14.04-XXL: build-ubuntu-14.04-XXL push-ubuntu-14.04-XXL dump-version-ubun
 # The only difference is that this image has official Docker installed.
 ###
 build-ubuntu-14.04-XXL-enterprise:
-	docker-cache-shim pull ${IMAGE_REPO}
+	docker-cache-shim pull ${IMAGE_REPO} || true
 	echo "Building Docker image ubuntu-14.04-XXL-enterprise-$(VERSION)"
 	docker build $(NO_CACHE) --build-arg IMAGE_TAG=ubuntu-14.04-XXL-enterprise-$(VERSION) \
 	-t $(IMAGE_REPO):ubuntu-14.04-XXL-enterprise-$(VERSION) \
@@ -80,7 +80,7 @@ ubuntu-14.04-XXL-enterprise: build-ubuntu-14.04-XXL-enterprise push-ubuntu-14.04
 # The images matches the content of Ubuntu 14.04 XXL except network services.
 ###
 build-ubuntu-14.04-XL:
-	docker-cache-shim pull ${IMAGE_REPO}
+	docker-cache-shim pull ${IMAGE_REPO} || true
 	echo "Building Docker image ubuntu-14.04-XL-$(VERSION)"
 	docker build $(NO_CACHE) --build-arg IMAGE_TAG=ubuntu-14.04-XL-$(VERSION) \
 	-t $(IMAGE_REPO):ubuntu-14.04-XL-$(VERSION) \

--- a/circleci-install
+++ b/circleci-install
@@ -8,9 +8,8 @@ export CIRCLECI_PKG_DIR=/opt/circleci
 
 if ! [ -d $CIRCLECI_PKG_DIR ]; then
     mkdir -p $CIRCLECI_PKG_DIR
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR
 fi
-
-chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR
 
 function as_user() {
     sudo -H -u ${CIRCLECI_USER} $@

--- a/circleci-provision-scripts/nodejs.sh
+++ b/circleci-provision-scripts/nodejs.sh
@@ -69,7 +69,7 @@ function install_nodejs_version_precompile() {
 
     maybe_run_apt_update
     apt-get install circleci-nodejs-$NODEJS_VERSION
-    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/nodejs
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/nodejs/v$NODEJS_VERSION
     set_nodejs_default $NODEJS_VERSION
 }
 

--- a/circleci-provision-scripts/php.sh
+++ b/circleci-provision-scripts/php.sh
@@ -66,7 +66,7 @@ function install_php_version_precompile() {
 
     maybe_run_apt_update
     apt-get install circleci-php-$PHP_VERSION
-    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/php
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/php/$PHP_VERSION
 }
 
 function install_php_version() {

--- a/circleci-provision-scripts/python.sh
+++ b/circleci-provision-scripts/python.sh
@@ -48,7 +48,7 @@ function install_python_version_precompile() {
 
     maybe_run_apt_update
     apt-get install circleci-python-$PYTHON_VERSION
-    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/python
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/python/$PYTHON_VERSION
 }
 
 function set_python_default() {

--- a/circleci-provision-scripts/ruby.sh
+++ b/circleci-provision-scripts/ruby.sh
@@ -76,7 +76,7 @@ function install_ruby_version_precompile() {
 
     maybe_run_apt_update
     apt-get install circleci-ruby-$INSTALL_RUBY_VERSION
-    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/ruby/
+    chown -R $CIRCLECI_USER:$CIRCLECI_USER $CIRCLECI_PKG_DIR/ruby/ruby-$INSTALL_RUBY_VERSION
 
     (cat <<'EOF'
 echo Installing Ruby version: $INSTALL_RUBY_VERSION


### PR DESCRIPTION
Newer Docker invalidates cache when files are chowned even if the chown doesn't change anything. This makes the docker image very huge and eventually you are getting "no space left" error. To avoid this, we will chown directory that's newly installed.

