### PR TITLE
[CIRCLE-2115] Put the 14.04 images in the correct bucket.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ test-ubuntu-14.04-XXL:
 deploy-ubuntu-14.04-XXL:
 	./docker-export $(IMAGE_REPO):ubuntu-14.04-XXL-$(VERSION) > build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz
 	aws s3 cp ./build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz s3://circle-downloads/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz --acl public-read
+	aws s3 cp s3://circle-downloads/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz s3://lxc-images/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz --acl public-read
+	aws s3 cp s3://circle-downloads/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz s3://lxc-images-us-east-2/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz --acl public-read
+	aws s3 cp s3://circle-downloads/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz s3://lxc-images-us-west-2/build-image-ubuntu-14.04-XXL-$(VERSION).tar.gz --acl public-read
 
 ubuntu-14.04-XXL: build-ubuntu-14.04-XXL push-ubuntu-14.04-XXL dump-version-ubuntu-14.04-XXL test-ubuntu-14.04-XXL
 


### PR DESCRIPTION
We've been using the wrong bucket for too long and this means that
instances which start outside of us-east-1 are doing cross-region copies
of the container image when they boot. This causes many us-east-2 and
us-west-2 container hosts to fail to become ready because the download
times out.