### PR TITLE
Rev Oracle JDK 7 to more recent version

### DIFF
--- a/circleci-provision-scripts/java.sh
+++ b/circleci-provision-scripts/java.sh
@@ -39,7 +39,7 @@ function _install_oraclejdk() {
 function install_oraclejdk7() {
     echo '>>> Installing Oracle Java 7'
 
-    _install_oraclejdk 7 80
+    _install_oraclejdk 7 181
 }
 
 function install_oraclejdk8() {


### PR DESCRIPTION
Current version defaults to now-deprecated TLS v1.0, rev needed to use v1.2