### PR TITLE
Update to latest Ruby 2.3 version and make default

### DIFF
--- a/targets/ubuntu-14.04-XL/Dockerfile
+++ b/targets/ubuntu-14.04-XL/Dockerfile
@@ -83,7 +83,8 @@ RUN circleci-install ruby 2.2.4
 RUN circleci-install ruby 2.2.5
 RUN circleci-install ruby 2.3.0
 RUN circleci-install ruby 2.3.1
-RUN sudo -H -i -u ubuntu rvm use 2.2.4 --default
+RUN circleci-install ruby 2.3.7
+RUN sudo -H -i -u ubuntu rvm use 2.3.7 --default
 
 ADD circleci-provision-scripts/php.sh /opt/circleci-provision-scripts/php.sh
 RUN circleci-install php 5.5.31

--- a/targets/ubuntu-14.04-XXL-enterprise/Dockerfile
+++ b/targets/ubuntu-14.04-XXL-enterprise/Dockerfile
@@ -100,7 +100,8 @@ RUN circleci-install ruby 2.2.4
 RUN circleci-install ruby 2.2.5
 RUN circleci-install ruby 2.3.0
 RUN circleci-install ruby 2.3.1
-RUN sudo -H -i -u ubuntu rvm use 2.2.4 --default
+RUN circleci-install ruby 2.3.7
+RUN sudo -H -i -u ubuntu rvm use 2.3.7 --default
 
 ADD circleci-provision-scripts/php.sh /opt/circleci-provision-scripts/php.sh
 RUN circleci-install php 5.5.31

--- a/targets/ubuntu-14.04-enterprise/Dockerfile
+++ b/targets/ubuntu-14.04-enterprise/Dockerfile
@@ -65,7 +65,8 @@ ADD circleci-provision-scripts/ruby.sh /opt/circleci-provision-scripts/ruby.sh
 RUN circleci-install ruby 2.2.4
 RUN circleci-install ruby 2.3.0
 RUN circleci-install ruby 2.3.1
-RUN sudo -H -i -u ubuntu rvm use 2.2.4 --default
+RUN circleci-install ruby 2.3.7
+RUN sudo -H -i -u ubuntu rvm use 2.3.7 --default
 
 ADD circleci-provision-scripts/php.sh /opt/circleci-provision-scripts/php.sh
 RUN circleci-install php 5.6.17

--- a/tests/unit/ubuntu-14.04-XL/ruby.bats
+++ b/tests/unit/ubuntu-14.04-XL/ruby.bats
@@ -36,3 +36,7 @@ load ../test_helper_ruby
 @test "ruby: 2.3.1 works" {
     test_ruby 2.3.1
 }
+
+@test "ruby: 2.3.7 works" {
+    test_ruby 2.3.7
+}


### PR DESCRIPTION
Ruby 2.2 is EOL and shouldn't be a default that anyone is using anymore.
Though the older versions are still installed for backward
compatibility.