### PR TITLE
Allow specifying of docker version to install and avoid issues with using the current latest Docker version (18.06.2)

### DIFF
--- a/aws-vm.json
+++ b/aws-vm.json
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "docker_version_to_install": "17.06.0~ce-0~ubuntu"
+    },
     "builders" : [
         {
             "type": "amazon-ebs",
@@ -30,7 +33,7 @@
         {
             "type" : "shell",
             "inline" : [
-                "cd /tmp/circleci-provisioner && sudo su root -c './provision.sh' &&  echo done",
+                "cd /tmp/circleci-provisioner && sudo su root -c './provision.sh {{user `docker_version_to_install`}}' &&  echo done",
 
                 "sudo apt-get purge sshguard",
                 "sudo rm -rf /home/circleci/.ssh/authorized_keys /tmp/circleci-provisioner",

--- a/circleci-provision-scripts/docker.sh
+++ b/circleci-provision-scripts/docker.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
 function install_docker() {
-    echo '>>>> Installing Docker'
+    local SPECIFIED_DOCKER_VERSION=$1
+    if [ -n "$SPECIFIED_DOCKER_VERSION" ]; then
+        echo ">>>> Installing specific Docker version $SPECIFIED_DOCKER_VERSION"
+        sudo apt-get -y install gnupg-agent
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        sudo apt-get -y update
+        sudo apt-get -y install docker-ce=$SPECIFIED_DOCKER_VERSION
+    else
+        echo '>>>> Installing latest version of Docker'
+        curl https://get.docker.com/ | sh
+    fi
 
-    curl https://get.docker.com/ | sh
     useradd -m -s /bin/bash circleci
     sudo usermod -aG docker circleci
 }

--- a/provision.sh
+++ b/provision.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export VERBOSE=true
 export CIRCLECI_USER=circleci
+DOCKER_VERSION_TO_INSTALL=$1
 
 set -ex
 
@@ -49,7 +50,7 @@ circleci-install clojure
 circleci-install scala
 
 # Docker have be last - to utilize cache better
-circleci-install docker && circleci-install docker_compose
+circleci-install docker ${DOCKER_VERSION_TO_INSTALL} && circleci-install docker_compose
 
 circleci-install socat
 


### PR DESCRIPTION
## Purpose of PR
Currently image-builder installs the latest version of Docker onto the generated AMI; there isn't a way to specify a specific version to be installed. There is an issue with building Docker images with generated AMIs that use `18.06.2-ce` (the current latest Docker version); building results in the error `OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:297: copying bootstrap data to pipe caused \"write init-p: broken pipe\"": unknown`.

### Build error with generated AMI with `18.06.2-ce` installed
Here is an example of the error output when running the Docker image building test in [realitycheck](https://github.com/CircleCI-Public/realitycheck/blob/master/.circleci/config.yml#L45):

<img width="1188" alt="issue-with-18 06 2-ce" src="https://user-images.githubusercontent.com/2923526/52737739-07307a80-3008-11e9-954f-cef5bb7ee66d.png">

This issue is not encountered when building with the default vm-service AMI (that is used when a custom AMI is not specified) as it uses Docker `17.06.0-ce`:
<img width="510" alt="default-vm-service-ami" src="https://user-images.githubusercontent.com/2923526/52738212-19f77f00-3009-11e9-82d2-bd29d8bf6142.png">

### Proposed Solution
The changes in this branch add a user variable `docker_version_to_install` to the packer template to allow specifying the version of Docker installed. Allowing the version of Docker to be specified avoids the above-mentioned issue with `18.06.2-ce` and also gives the ability to avoid potential issues with future versions.

The value of `docker_version_to_install` in the template is set to install version `17.06.0-ce`, which is the same version used in the default vm-service AMI.
Values should correspond to a version listed by the `apt-cache madison show docker-ce` command.
Specifying an empty string value will cause the latest version of Docker to be installed.

#### Successful docker image building with an AMI generated from this branch with the default `docker_version_to_install` value:

<img width="699" alt="generated-ami-with-docker-17 06 0-ce" src="https://user-images.githubusercontent.com/2923526/52737993-9fc6fa80-3008-11e9-8ac9-1fde9201dee0.png">

#### Successful docker image building with an AMI generated from this branch, with `18.03.1~ce-0~ubuntu` specified as the `docker_version_to_install` value:

<img width="589" alt="generated AMI with docker version 18.03.1-ce installed" src="https://user-images.githubusercontent.com/2923526/52737105-845af000-3006-11e9-8ae1-244395125fd8.png">
