### PR TITLE
Updated the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 provision.sh
 .vagrant
 bats.log
+.DS_Store
+thumbs.db


### PR DESCRIPTION
## Description

As we all know that a `.gitignore` file is very necessary to any Git repository. `.DS_Store` is a MacOS directory cache file and `thumbs.db` is a windows directory cache file. Sometimes Mac/Windows users accidentally push these files which may interfere with other Mac/Windows users.